### PR TITLE
Feature/ads 751

### DIFF
--- a/src/components/Ribbon/Ribbon.stories.tsx
+++ b/src/components/Ribbon/Ribbon.stories.tsx
@@ -11,8 +11,44 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof Ribbon>;
 
+const baseArgs = {
+  children: 'Ribbon'
+};
+
 export const Playground: Story = {
   args: {
-    children: 'Ribbon'
+    ...baseArgs
+  }
+};
+
+export const WithShadow: Story = {
+  name: 'With shadow',
+  args: {
+    ...baseArgs,
+    withShadow: true
+  }
+};
+
+export const WithCenteredText: Story = {
+  name: 'With centered text',
+  args: {
+    ...baseArgs,
+    isCentered: true
+  }
+};
+
+export const WithConstrainedWidth: Story = {
+  name: 'With constrained width',
+  args: {
+    ...baseArgs,
+    isConstrained: true
+  }
+};
+
+export const WithInformationalVariant: Story = {
+  name: 'With informational variant',
+  args: {
+    ...baseArgs,
+    variant: 'informational'
   }
 };

--- a/src/components/Ribbon/Ribbon.test.tsx
+++ b/src/components/Ribbon/Ribbon.test.tsx
@@ -15,7 +15,7 @@ describe('Ribbon', () => {
   });
 
   it('applies text alignment class correctly', () => {
-    render(<Ribbon data-testid={testId} textAlign="center" />);
+    render(<Ribbon data-testid={testId} isCentered />);
     expect(screen.getByTestId(testId)).toHaveClass('bsds-text-center');
   });
 

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -2,7 +2,7 @@ import { HTMLAttributes, PropsWithChildren } from 'react';
 
 export interface RibbonProps extends PropsWithChildren<HTMLAttributes<HTMLDivElement>> {
   isConstrained?: boolean;
-  textAlign?: 'left' | 'center';
+  isCentered?: boolean;
   variant?: 'default' | 'informational';
   withShadow?: boolean;
 }
@@ -11,7 +11,7 @@ const Ribbon = ({
   children,
   className,
   variant = 'default',
-  textAlign = 'left',
+  isCentered = false,
   withShadow = false,
   isConstrained = false,
   ...rest
@@ -20,7 +20,7 @@ const Ribbon = ({
 
   const classesFromProps = [
     variant !== 'default' ? `${baseClass}-${variant}` : null,
-    textAlign !== 'left' ? `bsds-text-${textAlign}` : null,
+    isCentered ? `bsds-text-center` : null,
     withShadow ? `${baseClass}-shadow` : null,
     isConstrained ? `is-constrained` : null,
     className || null


### PR DESCRIPTION
Per [Anatomy Docs PR discussion](https://github.com/bos-sci/anatomy-docs/pull/329):

- Remove left-aligned text modifier, since left-aligned is the default.
- Additionally, change `textAlign` prop to `isCentered`, since text-center is the only modifier, and this boolean option creates a better user experience in Storybook.
- Update test file to match change.
- Add new stories for each modifier in Storybook.