### PR TITLE
Feature/ads 712 replace empty string props with undefined in Storybook

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -11,16 +11,16 @@ const meta = {
   },
   argTypes: {
     variant: {
-      options: ['', 'assertive', 'ghost', 'subtle'],
+      options: [undefined, 'assertive', 'ghost', 'subtle'],
       control: { type: 'radio' }
     },
     size: {
-      options: ['', 'small'],
+      options: [undefined, 'small'],
       control: { type: 'radio' }
     },
     // TODO: What icons do we want to support and how do we handle them in Storybook
     icon: {
-      options: ['', 'plus', 'chevronRight', 'close'],
+      options: [undefined, 'plus', 'chevronRight', 'close'],
       control: { type: 'select' }
     },
     iconAlignment: { control: 'radio', if: { arg: 'icon' } },

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,12 +1,11 @@
-import { ButtonHTMLAttributes, ForwardedRef, forwardRef, ReactNode, useEffect, useState } from 'react';
+import { ButtonHTMLAttributes, ForwardedRef, forwardRef, useEffect, useState } from 'react';
 import Icon from '../Icon';
 
 export type ButtonVariants = 'assertive' | 'ghost' | 'subtle';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  children?: ReactNode;
   variant?: ButtonVariants;
-  size?: 'small' | null;
+  size?: 'small';
   icon?: string;
   iconAlignment?: 'left' | 'right';
   iconSize?: 'sm' | 'md' | 'lg' | '2x' | '3x' | '4x' | 'base';

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,7 +1,7 @@
 import { ButtonHTMLAttributes, ForwardedRef, forwardRef, ReactNode, useEffect, useState } from 'react';
 import Icon from '../Icon';
 
-export type ButtonVariants = '' | 'assertive' | 'ghost' | 'subtle';
+export type ButtonVariants = 'assertive' | 'ghost' | 'subtle';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children?: ReactNode;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,9 +1,11 @@
-import { ButtonHTMLAttributes, ForwardedRef, forwardRef, useEffect, useState } from 'react';
+import { ButtonHTMLAttributes, ForwardedRef, forwardRef, useEffect, useState, ReactNode } from 'react';
 import Icon from '../Icon';
 
 export type ButtonVariants = 'assertive' | 'ghost' | 'subtle';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  // TODO: ADS-712 consider removing children from extended props that include it
+  children?: ReactNode;
   variant?: ButtonVariants;
   size?: 'small';
   icon?: string;

--- a/src/components/ContentCard/ContentCard.stories.tsx
+++ b/src/components/ContentCard/ContentCard.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
   component: ContentCard,
   argTypes: {
     variant: {
-      options: ['', 'border-light', 'border-ghost', 'ghost'],
+      options: [undefined, 'border-light', 'border-ghost', 'ghost'],
       control: { type: 'radio' }
     },
     gradientBrand: {

--- a/src/components/ProductCard/ProductCard.stories.tsx
+++ b/src/components/ProductCard/ProductCard.stories.tsx
@@ -8,6 +8,10 @@ const meta = {
   title: 'Components/Product card',
   component: ProductCard,
   argTypes: {
+    variant: {
+      options: [undefined, 'ghost', 'border-light', 'border-ghost'],
+      control: { type: 'radio' }
+    },
     dropShadow: {
       if: { arg: 'gradientBrand', truthy: false }
     },

--- a/src/components/Ribbon/Ribbon.stories.tsx
+++ b/src/components/Ribbon/Ribbon.stories.tsx
@@ -5,7 +5,13 @@ import Ribbon from './Ribbon';
 const meta = {
   title: 'Components/Ribbon',
   component: Ribbon,
-  tags: ['autodocs']
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      options: [undefined, 'informational'],
+      control: { type: 'radio' }
+    }
+  }
 } satisfies Meta<typeof Ribbon>;
 
 export default meta;

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -3,14 +3,14 @@ import { HTMLAttributes, PropsWithChildren } from 'react';
 export interface RibbonProps extends PropsWithChildren<HTMLAttributes<HTMLDivElement>> {
   isConstrained?: boolean;
   isCentered?: boolean;
-  variant?: 'default' | 'informational';
+  variant?: 'informational';
   withShadow?: boolean;
 }
 
 const Ribbon = ({
   children,
   className,
-  variant = 'default',
+  variant,
   isCentered = false,
   withShadow = false,
   isConstrained = false,
@@ -19,7 +19,7 @@ const Ribbon = ({
   const baseClass = 'bsds-ribbon';
 
   const classesFromProps = [
-    variant !== 'default' ? `${baseClass}-${variant}` : null,
+    variant ? `${baseClass}-${variant}` : null,
     isCentered ? `bsds-text-center` : null,
     withShadow ? `${baseClass}-shadow` : null,
     isConstrained ? `is-constrained` : null,

--- a/src/components/Stoplight/Stoplight.stories.tsx
+++ b/src/components/Stoplight/Stoplight.stories.tsx
@@ -13,10 +13,10 @@ const meta = {
       options: ['red', 'yellow', 'green']
     },
     textColor: {
-      options: ['default', 'ghost']
+      options: [undefined, 'ghost']
     },
     size: {
-      options: ['default', 'assertive', 'subtle']
+      options: [undefined, 'assertive', 'subtle']
     }
   },
   tags: ['autodocs']

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -12,6 +12,10 @@ const meta = {
   argTypes: {
     texts: {
       control: false
+    },
+    variant: {
+      options: [undefined, 'accent', 'assertive', 'featured', 'subtle'],
+      control: { type: 'radio' }
     }
   }
 } satisfies Meta<typeof Tag>;

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -4,7 +4,7 @@ import { ReactNode, useState, useEffect } from 'react';
 
 export interface TagProps {
   children: ReactNode;
-  variant?: 'accent' | 'assertive' | 'featured' | 'subtle' | '';
+  variant?: 'accent' | 'assertive' | 'featured' | 'subtle';
   isGhost?: boolean;
   texts?: {
     featuredTag?: string;


### PR DESCRIPTION
Replace empty strings that were being used as default options in component stories.

For example, to un-set a Button variant, like `<Button variant="assertive" />`, inside Storybook, a blank radio button option was provided. If used, the result was `<Button variant="" />` in the demo code. By replacing empty strings with `undefined`, the radio button works the same way, but the resulting code is just `<Button />`

PR additionally removes the `default` option from Ribbon variant, Stoplight textColor, and Stoplight sizes.