### PR TITLE
Feature/ads 802 export types to share between components and stories

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -7,7 +7,7 @@
 //   https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html
 
 import { Children, createRef, Fragment, ReactElement, useEffect, useId, useRef, useState } from 'react';
-import HeadingElement from '../Heading';
+import HeadingElement, { HeadingLevel } from '../Heading';
 import AccordionHeading from './AccordionHeading';
 import { AccordionPanelProps } from './AccordionPanel';
 
@@ -15,7 +15,7 @@ export type AccordionProps = {
   /**
    * Heading to be used for the panel headers
    */
-  headingLevel: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  headingLevel: HeadingLevel;
   /**
    * Accordions appear in a container with condensed spacing
    */

--- a/src/components/Accordion/AccordionPanel.tsx
+++ b/src/components/Accordion/AccordionPanel.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable react/no-unused-prop-types */
 import { ReactNode } from 'react';
+import { StoplightColor } from '../Stoplight';
 
 export interface AccordionPanelProps {
   heading: string;
-  stoplightColor?: 'red' | 'yellow' | 'green';
+  stoplightColor?: StoplightColor;
   children: ReactNode;
 }
 

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -2,6 +2,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import Button from './Button';
+import { BUTTON_ICONS, BUTTON_SIZES, BUTTON_VARIANTS } from './Button.types';
 
 const meta = {
   title: 'Components/Button',
@@ -11,16 +12,16 @@ const meta = {
   },
   argTypes: {
     variant: {
-      options: [undefined, 'assertive', 'ghost', 'subtle'],
+      options: [undefined, ...BUTTON_VARIANTS],
       control: { type: 'radio' }
     },
     size: {
-      options: [undefined, 'small'],
+      options: [undefined, ...BUTTON_SIZES],
       control: { type: 'radio' }
     },
     // TODO: What icons do we want to support and how do we handle them in Storybook
     icon: {
-      options: [undefined, 'plus', 'chevronRight', 'close'],
+      options: [undefined, ...BUTTON_ICONS],
       control: { type: 'select' }
     },
     iconAlignment: { control: 'radio', if: { arg: 'icon' } },

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -2,7 +2,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import Button from './Button';
-import { BUTTON_ICONS, BUTTON_SIZES, BUTTON_VARIANTS } from './';
+import { BUTTON_ICONS, BUTTON_SIZES, BUTTON_VARIANTS } from './Button.types';
 
 const meta = {
   title: 'Components/Button',

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -2,7 +2,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import Button from './Button';
-import { BUTTON_ICONS, BUTTON_SIZES, BUTTON_VARIANTS } from './Button.types';
+import { BUTTON_ICONS, BUTTON_SIZES, BUTTON_VARIANTS } from './';
 
 const meta = {
   title: 'Components/Button',

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,16 +1,14 @@
 import { ButtonHTMLAttributes, ForwardedRef, forwardRef, useEffect, useState, ReactNode } from 'react';
 import Icon from '../Icon';
-
-export type ButtonVariants = 'assertive' | 'ghost' | 'subtle';
+import { ButtonIconSizes, ButtonSizes, ButtonVariants } from './Button.types';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  // TODO: ADS-712 consider removing children from extended props that include it
   children?: ReactNode;
   variant?: ButtonVariants;
-  size?: 'small';
+  size?: ButtonSizes;
   icon?: string;
   iconAlignment?: 'left' | 'right';
-  iconSize?: 'sm' | 'md' | 'lg' | '2x' | '3x' | '4x' | 'base';
+  iconSize?: ButtonIconSizes;
 }
 
 const Button = forwardRef(

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,6 +1,6 @@
 import { ButtonHTMLAttributes, ForwardedRef, forwardRef, useEffect, useState, ReactNode } from 'react';
 import Icon from '../Icon';
-import { ButtonIconSizes, ButtonSizes, ButtonVariants } from './Button.types';
+import { ButtonIconSizes, ButtonSizes, ButtonVariants } from './';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children?: ReactNode;

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -1,0 +1,11 @@
+export const BUTTON_VARIANTS = ['assertive', 'ghost', 'subtle'] as const;
+export type ButtonVariants = (typeof BUTTON_VARIANTS)[number];
+
+export const BUTTON_ICON_SIZES = ['sm', 'md', 'lg', '2x', '3x', '4x', 'base'] as const;
+export type ButtonIconSizes = (typeof BUTTON_ICON_SIZES)[number];
+
+export const BUTTON_SIZES = ['small'] as const;
+export type ButtonSizes = (typeof BUTTON_SIZES)[number];
+
+export const BUTTON_ICONS = ['plus', 'chevronRight', 'close'];
+export type ButtonIcons = (typeof BUTTON_ICONS)[number];

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,2 +1,3 @@
 export { default } from './Button';
 export * from './Button';
+export * from './Button.types';

--- a/src/components/ContentCard/ContentCard.stories.tsx
+++ b/src/components/ContentCard/ContentCard.stories.tsx
@@ -3,13 +3,14 @@ import type { Meta, StoryObj } from '@storybook/react';
 import ContentCard from './ContentCard';
 import Tag from '../Tag/Tag';
 import Image from '../Image/Image';
+import { CARD_VARIANTS } from './ContentCard.types';
 
 const meta = {
   title: 'Components/Content card',
   component: ContentCard,
   argTypes: {
     variant: {
-      options: [undefined, 'border-light', 'border-ghost', 'ghost'],
+      options: [undefined, ...CARD_VARIANTS],
       control: { type: 'radio' }
     },
     gradientBrand: {

--- a/src/components/ContentCard/ContentCard.tsx
+++ b/src/components/ContentCard/ContentCard.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, cloneElement, useState, useEffect, useId } from 'react';
-import HeadingElement from '../Heading';
+import HeadingElement, { HeadingLevel } from '../Heading';
 import { ImageProps } from '../Image';
 import { TagProps } from '../Tag';
 import Link from '../Link';
@@ -11,7 +11,7 @@ interface PlainCardProps {
     cardDescription: string;
   };
   variant?: string;
-  headingLevel: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  headingLevel: Exclude<HeadingLevel, 'h1'>;
   tag?: ReactElement<TagProps>;
   image?: ReactElement<ImageProps>;
   icon?: boolean;

--- a/src/components/ContentCard/ContentCard.types.ts
+++ b/src/components/ContentCard/ContentCard.types.ts
@@ -1,0 +1,2 @@
+export const CARD_VARIANTS = ['ghost', 'border-light', 'border-ghost'] as const;
+export type CardVariant = (typeof CARD_VARIANTS)[number];

--- a/src/components/ContentCard/index.ts
+++ b/src/components/ContentCard/index.ts
@@ -1,2 +1,3 @@
 export { default } from './ContentCard';
 export * from './ContentCard';
+export * from './ContentCard.types';

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { HeadingLevel } from './Heading.types';
 
 export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
-  headingLevel: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  headingLevel: HeadingLevel;
 }
 
 const HeadingElement = ({ headingLevel = 'h2', children, ...attrs }: HeadingProps) => {

--- a/src/components/Heading/Heading.types.ts
+++ b/src/components/Heading/Heading.types.ts
@@ -1,0 +1,3 @@
+export const HEADING_LEVELS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
+
+export type HeadingLevel = (typeof HEADING_LEVELS)[number];

--- a/src/components/Heading/index.ts
+++ b/src/components/Heading/index.ts
@@ -1,2 +1,3 @@
 export { default } from './Heading';
 export * from './Heading';
+export * from './Heading.types';

--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -3,7 +3,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import Image from './Image';
 import { IMAGE_RATIO_OPTIONS } from './Image.types';
 
-const ratioOptionsString = IMAGE_RATIO_OPTIONS.map((ratio) => `"${ratio}"`).join(', ');
+/**
+ * The 50:50 ratio should not be used in a standalone Image, but needs to be
+ * available for when it's a child of some other components (e.g. ProductCard).
+ */
+const ratioOptions = IMAGE_RATIO_OPTIONS.filter((option) => option !== '50:50');
+
+const ratioOptionsString = ratioOptions.map((ratio) => `"${ratio}"`).join(', ');
 
 const meta = {
   title: 'Components/Image',
@@ -13,7 +19,7 @@ const meta = {
   },
   argTypes: {
     ratio: {
-      options: [...IMAGE_RATIO_OPTIONS],
+      options: [...ratioOptions],
       table: {
         type: { summary: ratioOptionsString }
       }

--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import Image from './Image';
+import { IMAGE_RATIO_OPTIONS } from './Image.types';
+
+const ratioOptionsString = IMAGE_RATIO_OPTIONS.map((ratio) => `"${ratio}"`).join(', ');
 
 const meta = {
   title: 'Components/Image',
@@ -10,9 +13,9 @@ const meta = {
   },
   argTypes: {
     ratio: {
-      options: ['1:1', '4:3', '16:9', '21:9'],
+      options: [...IMAGE_RATIO_OPTIONS],
       table: {
-        type: { summary: `"1:1", "4:3", "16:9", "21:9"` }
+        type: { summary: ratioOptionsString }
       }
     }
   },

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -1,7 +1,8 @@
 import { ImgHTMLAttributes, useEffect, useId, useState } from 'react';
+import { ImageRatio } from './Image.types';
 
 interface BaseProps extends ImgHTMLAttributes<HTMLImageElement> {
-  ratio?: Ratio;
+  ratio?: ImageRatio;
   hasCaption?: boolean;
   isCaptionCentered?: boolean;
   isGhost?: boolean;
@@ -20,7 +21,6 @@ type AltTextProps =
       alt: string;
     };
 
-export type Ratio = '1:1' | '4:3' | '16:9' | '21:9' | '50:50';
 export type ImageProps = BaseProps & AltTextProps;
 
 const Image = (props: ImageProps): JSX.Element => {

--- a/src/components/Image/Image.types.ts
+++ b/src/components/Image/Image.types.ts
@@ -1,0 +1,2 @@
+export const IMAGE_RATIO_OPTIONS = ['1:1', '4:3', '16:9', '21:9', '50:50'] as const;
+export type ImageRatio = (typeof IMAGE_RATIO_OPTIONS)[number];

--- a/src/components/Image/index.ts
+++ b/src/components/Image/index.ts
@@ -1,2 +1,3 @@
 export { default } from './Image';
 export * from './Image';
+export * from './Image.types';

--- a/src/components/ProductCard/ProductCard.stories.tsx
+++ b/src/components/ProductCard/ProductCard.stories.tsx
@@ -3,13 +3,14 @@ import type { Meta, StoryObj } from '@storybook/react';
 import ProductCard from './ProductCard';
 import Tag from '../Tag/Tag';
 import Image from '../Image/Image';
+import { CARD_VARIANTS } from '../ContentCard';
 
 const meta = {
   title: 'Components/Product card',
   component: ProductCard,
   argTypes: {
     variant: {
-      options: [undefined, 'ghost', 'border-light', 'border-ghost'],
+      options: [undefined, ...CARD_VARIANTS],
       control: { type: 'radio' }
     },
     dropShadow: {

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -1,10 +1,9 @@
 import { ReactElement, useState, useEffect, cloneElement, useId, useRef } from 'react';
-import HeadingElement from '../Heading';
+import HeadingElement, { HeadingLevel } from '../Heading';
 import Link from '../Link';
 import { TagProps } from '../Tag';
 import { ImageProps } from '../Image';
-
-export type ProductCardVariants = '' | 'ghost' | 'border-light' | 'border-ghost';
+import { CardVariant } from '../ContentCard';
 export interface ProductCardProps {
   tag?: ReactElement<TagProps>;
   texts: {
@@ -12,9 +11,9 @@ export interface ProductCardProps {
     description: string;
   };
   linkTo: string;
-  headingLevel?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  headingLevel?: Exclude<HeadingLevel, 'h1'>;
   assertiveTitle?: boolean;
-  variant?: ProductCardVariants;
+  variant?: CardVariant;
   image?: ReactElement<ImageProps>;
   gradientBrand?: boolean;
   dropShadow?: boolean;

--- a/src/components/Ribbon/Ribbon.stories.tsx
+++ b/src/components/Ribbon/Ribbon.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import Ribbon from './Ribbon';
+import { RIBBON_VARIANTS } from './Ribbon.types';
 
 const meta = {
   title: 'Components/Ribbon',
@@ -8,7 +9,7 @@ const meta = {
   tags: ['autodocs'],
   argTypes: {
     variant: {
-      options: [undefined, 'informational'],
+      options: [undefined, ...RIBBON_VARIANTS],
       control: { type: 'radio' }
     }
   }

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -1,9 +1,10 @@
 import { HTMLAttributes, PropsWithChildren } from 'react';
+import { RibbonVariant } from './Ribbon.types';
 
 export interface RibbonProps extends PropsWithChildren<HTMLAttributes<HTMLDivElement>> {
   isConstrained?: boolean;
   isCentered?: boolean;
-  variant?: 'informational';
+  variant?: RibbonVariant;
   withShadow?: boolean;
 }
 

--- a/src/components/Ribbon/Ribbon.types.ts
+++ b/src/components/Ribbon/Ribbon.types.ts
@@ -1,0 +1,2 @@
+export const RIBBON_VARIANTS = ['informational'];
+export type RibbonVariant = (typeof RIBBON_VARIANTS)[number];

--- a/src/components/Stoplight/Stoplight.stories.tsx
+++ b/src/components/Stoplight/Stoplight.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import Stoplight from './Stoplight';
+import { STOPLIGHT_COLORS, STOPLIGHT_SIZES, STOPLIGHT_TEXT_COLORS } from './Stoplight.types';
 
 const meta = {
   title: 'Components/Stoplight',
@@ -10,13 +11,13 @@ const meta = {
   },
   argTypes: {
     lightColor: {
-      options: ['red', 'yellow', 'green']
+      options: [...STOPLIGHT_COLORS]
     },
     textColor: {
-      options: [undefined, 'ghost']
+      options: [undefined, ...STOPLIGHT_TEXT_COLORS]
     },
     size: {
-      options: [undefined, 'assertive', 'subtle']
+      options: [undefined, ...STOPLIGHT_SIZES]
     }
   },
   tags: ['autodocs']

--- a/src/components/Stoplight/Stoplight.tsx
+++ b/src/components/Stoplight/Stoplight.tsx
@@ -1,10 +1,11 @@
 import { ReactNode } from 'react';
+import { StoplightColor, StoplightSize, StoplightTextColor } from './Stoplight.types';
 
 export interface StoplightProps {
   children: ReactNode;
-  lightColor: 'red' | 'yellow' | 'green';
-  textColor?: 'ghost';
-  size?: 'assertive' | 'subtle';
+  lightColor: StoplightColor;
+  textColor?: StoplightTextColor;
+  size?: StoplightSize;
 }
 
 const Stoplight = ({ children, lightColor, textColor, size }: StoplightProps): JSX.Element => {

--- a/src/components/Stoplight/Stoplight.types.ts
+++ b/src/components/Stoplight/Stoplight.types.ts
@@ -1,0 +1,8 @@
+export const STOPLIGHT_COLORS = ['red', 'yellow', 'green'] as const;
+export type StoplightColor = (typeof STOPLIGHT_COLORS)[number];
+
+export const STOPLIGHT_SIZES = ['assertive', 'subtle'] as const;
+export type StoplightSize = (typeof STOPLIGHT_SIZES)[number];
+
+export const STOPLIGHT_TEXT_COLORS = ['ghost'] as const;
+export type StoplightTextColor = (typeof STOPLIGHT_TEXT_COLORS)[number];

--- a/src/components/Stoplight/index.ts
+++ b/src/components/Stoplight/index.ts
@@ -1,2 +1,3 @@
 export { default } from './Stoplight';
 export * from './Stoplight';
+export * from './Stoplight.types';

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import Tag from './Tag';
+import { TAG_VARIANTS } from './Tag.types';
 
 const meta = {
   title: 'Components/Tag',
@@ -14,7 +15,7 @@ const meta = {
       control: false
     },
     variant: {
-      options: [undefined, 'accent', 'assertive', 'featured', 'subtle'],
+      options: [undefined, ...TAG_VARIANTS],
       control: { type: 'radio' }
     }
   }

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,10 +1,11 @@
 // TODO: Create default texts object and assign in function params or Tag.defaultProps instead of at each use case then re-enable control in story
 
 import { ReactNode, useState, useEffect } from 'react';
+import { TagVariant } from './Tag.types';
 
 export interface TagProps {
   children: ReactNode;
-  variant?: 'accent' | 'assertive' | 'featured' | 'subtle';
+  variant?: TagVariant;
   isGhost?: boolean;
   texts?: {
     featuredTag?: string;

--- a/src/components/Tag/Tag.types.ts
+++ b/src/components/Tag/Tag.types.ts
@@ -1,0 +1,2 @@
+export const TAG_VARIANTS = ['accent', 'assertive', 'featured', 'subtle'] as const;
+export type TagVariant = (typeof TAG_VARIANTS)[number];


### PR DESCRIPTION
Create `Component.type.ts` files for components where strings of options were being duplicated on components and their stories. These changes will allow for edits to a single source of truth that will be reflected in both locations.

For [ADS-802 Export types](https://bsc-oit.atlassian.net/browse/ADS-802)