### PR TITLE
bug/ads-1164 refactor co-branded logo style for primary nav

### DIFF
--- a/public/styles/components/nav-primary/_nav-primary-bar.scss
+++ b/public/styles/components/nav-primary/_nav-primary-bar.scss
@@ -18,17 +18,23 @@
     }
 
     .bsds-nav-link-logo {
-      display: flex;
-      flex-wrap: wrap;
-      align-self: center;
-      box-sizing: content-box;
-      width: auto;
-      max-height: 3.375rem;
-      margin: auto;
-      padding: var(--space-2x);
+      &:is(img) {
+        max-height: 3.375rem;
+      }
 
-      &:focus {
-        @include focus-default-inset;
+      &:is(img),
+      svg {
+        display: flex;
+        flex-wrap: wrap;
+        align-self: center;
+        box-sizing: content-box;
+        width: auto;
+        margin: auto;
+        padding: var(--space-2x);
+
+        &:focus {
+          @include focus-default-inset;
+        }
       }
     }
 
@@ -156,8 +162,11 @@
       flex-direction: row;
 
       .bsds-nav-link-logo {
-        margin: 0;
-        padding: var(--space-sm) var(--space-2x);
+        &:is(img),
+        svg {
+          margin: 0;
+          padding: var(--space-sm) var(--space-2x);
+        }
       }
     }
   }


### PR DESCRIPTION
Secondary logo was aligned to the bottom of nav. 
Fixed to look like in prod: https://www.anatomydesignsystem.com/components/primary-navigation/example/primaryNavigationCobranded